### PR TITLE
Adds QDB support and a cache for random quotes.

### DIFF
--- a/lib/WWW/BashOrg.pm
+++ b/lib/WWW/BashOrg.pm
@@ -167,7 +167,7 @@ either L<http://bash.org/> or L<http://qdb.us/>.
     );
 
 Returns a newly baked C<WWW::BashOrg> object. All arguments are options, so far there
-are only two arguments is available:
+are only two arguments are available:
 
 =head3 C<ua>
 


### PR DESCRIPTION
Hi. This patch adds support for qdb.us and caching of random quotes so fewer page fetches are required.

I had originally intended to upload a module to CPAN to support this (I wrote the code about a year ago : https://gist.github.com/jbarrett/5142315), but was wondering if it's better placed in WWW::BashOrg.

This patch should have no effect on existing code using your module.
